### PR TITLE
Route namespacing

### DIFF
--- a/example/lib/example/router.ex
+++ b/example/lib/example/router.ex
@@ -1,7 +1,9 @@
 defmodule Example.Router do
   use Pilot.Router
 
-  get "/test" do
-    "Hello, world!"
+  namespace "/users", to: Example.Router.Users
+
+  get "/hello" do
+    "Hello from Router!"
   end
 end

--- a/example/lib/example/router/users.ex
+++ b/example/lib/example/router/users.ex
@@ -1,0 +1,7 @@
+defmodule Example.Router.Users do
+  use Pilot.Router
+  
+  get "/hello" do
+    "Hello from Users!"
+  end
+end

--- a/lib/pilot/router.ex
+++ b/lib/pilot/router.ex
@@ -97,13 +97,15 @@ defmodule Pilot.Router do
   defmacro namespace(path, options) do
     quote bind_quoted: [path: path, options: options] do
       {target, options} = Keyword.pop(options, :to)
+      {options, plug_options} = Keyword.split(options, [:host, :private, :assigns])
+      plug_options = Keyword.get(plug_options, :init_opts, plug_options)
 
       if is_nil(target) or !is_atom(target) do
         raise ArgumentError, message: "expected :to to be an alias or an atom"
       end
 
       @target_namespace target
-      @target_opts      target.init([])
+      @target_opts      target.init(plug_options)
 
       match path <> "/*glob", options do
         Pilot.Router.Utils.namespace(


### PR DESCRIPTION
Adds `namespace` macro. Allows specifying outside routers to handle routes.

For example, the following allows the `Example.Router.Users` router to handle all requests on routes prefixed by `/users`:
```
defmodule Example.Router do
  use Pilot.Router

  namespace "/users", to: Example.Router.Users
end
```

Resolves functionality requested by #5 